### PR TITLE
move cupy out of install requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ packages = find:
 include_package_data = True
 install_requires =
     qutip>=5.0.0.dev0
-    cupy
 setup_requires =
     packaging
 

--- a/src/qutip_cupy/__init__.py
+++ b/src/qutip_cupy/__init__.py
@@ -8,8 +8,10 @@ import warnings
 try:
     import cupy
 except ModuleNotFoundError:
-    raise RuntimeError('''qutip_cupy requires cupy to be installed, please install
-                         cupy by following the instructions at https://docs.cupy.dev/en/stable/install.html''')
+    raise RuntimeError(
+        "qutip_cupy requires cupy to be installed, please install "
+        "cupy by following the instructions at https://docs.cupy.dev/en/stable/install.html"
+    )
 del cupy
 
 with warnings.catch_warnings():

--- a/src/qutip_cupy/__init__.py
+++ b/src/qutip_cupy/__init__.py
@@ -6,11 +6,10 @@
 import warnings
 
 try:
-    import cupy
+    __import__("cupy")
 except ModuleNotFoundError:
     raise RuntimeError('''qutip_cupy requires cupy to be installed, please install
                          cupy by following the instructions at https://docs.cupy.dev/en/stable/install.html''')
-del cupy
 
 with warnings.catch_warnings():
      warnings.filterwarnings(

--- a/src/qutip_cupy/__init__.py
+++ b/src/qutip_cupy/__init__.py
@@ -5,6 +5,13 @@
 # to an official optional dependency
 import warnings
 
+try:
+    import cupy
+except ModuleNotFoundError:
+    raise RuntimeError('''qutip_cupy requires cupy to be installed, please install
+                         cupy by following the instructions at https://docs.cupy.dev/en/stable/install.html''')
+del cupy
+
 with warnings.catch_warnings():
      warnings.filterwarnings(
         action ='ignore',


### PR DESCRIPTION
This also adds a check that cupy has been propery nstalled to __init__

@hodgestar  this is what we were talking with @nathanshammah  today. 
I had skipped the change on the last PR.

If this is okey with you I'll add the corresponding changes in the readme