### PR TITLE
readme updated with qutip.devmajor and cupy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Installation
 
 `qutip-cupy` is not yet officially released.
 
-If you want to try out the package you will need to have a CUDA enabled GPU, to install `QuTiP >5.0.0` and `CuPy`.
+If you want to try out the package you will need to have a CUDA enabled GPU, `QuTiP >5.0.0` and `CuPy`.
 We recommend using a conda environment.
 To install `CuPy` we recommend the following steps:
 

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ Installation
 `qutip-cupy` is not yet officially released.
 
 If you want to try out the package you will need to have a CUDA enabled GPU, `QuTiP >5.0.0` and `CuPy`.
-We recommend using a conda environment.
+We recommend using a conda environment `Python >= 3.7`.
 To install `CuPy` we recommend the following steps:
 
 - conda install cudatoolkit
 - conda install -c conda-forge cupy
 
-To install `QuTiP >5.0.0` while it is not yet released we recommend
+To install `QuTiP >5.0.0` while it is not yet released we recommend:
 
 - python -mpip install git+https://github.com/qutip/qutip.git@dev.major
 
-Now you can safely install `qutip-cupy`
+Now you can safely install `qutip_cupy`
 
-- python -mpip install https://github.com/qutip/qutip-cupy.git
+- python -mpip install git+https://github.com/qutip/qutip-cupy.git

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ If you want to try out the package you will need to have a CUDA enabled GPU, `Qu
 We recommend using a conda environment `Python >= 3.7`.
 To install `CuPy` we recommend the following steps:
 
-- conda install cudatoolkit
 - conda install -c conda-forge cupy
 
 To install `QuTiP >5.0.0` while it is not yet released we recommend:

--- a/README.md
+++ b/README.md
@@ -19,3 +19,18 @@ Installation
 ------------
 
 `qutip-cupy` is not yet officially released.
+
+If you want to try out the package you will need to have a CUDA enabled GPU, to install `QuTiP >5.0.0` and `CuPy`.
+We recommend using a conda environment.
+To install `CuPy` we recommend the following steps:
+
+- conda install cudatoolkit
+- conda install -c conda-forge cupy
+
+To install `QuTiP >5.0.0` while it is not yet released we recommend
+
+- python -mpip install git+https://github.com/qutip/qutip.git@dev.major
+
+Now you can safely install `qutip-cupy`
+
+- python -mpip install https://github.com/qutip/qutip-cupy.git


### PR DESCRIPTION
This updates the readme with an step by step explanation of how to install the unreleased version and required libraries,  Just for adventurers.

See https://github.com/qutip/qutip-cupy/issues/14. About usage, maybe we should point to the data_layer documentation. In any case there is not much usage we can reap from it now, but I have a basic notebook with examples already is there a correct place to hang it?
