### PR TITLE
fix_promote_to_ket_default_in __init__

### DIFF
--- a/src/qutip_cupy/dense.py
+++ b/src/qutip_cupy/dense.py
@@ -24,7 +24,8 @@ class CuPyDense(data.Data):
         Data to be stored.
     shape: (int, int)
         Defaults to ``None``. If ``None`` will infer the shape from ``data``,
-        else it will set the shape for the internal CuPy array.
+        else it will set the shape for the internal CuPy array. If `` data`` has shape
+        of length less than one then ``data`` will be reshaped as a ket.
     copy: bool
         Defaults to ``True``. Whether to make a copy of
         the elements in ``data`` or not.
@@ -38,8 +39,8 @@ class CuPyDense(data.Data):
         if shape is None:
             shape = base.shape
             # Promote to a ket by default if passed 1D data.
-            if len(shape) == 1:
-                shape = (shape[0], 1)
+        if len(shape) == 1:
+            shape = (shape[0], 1)
         if not (
             len(shape) == 2
             and isinstance(shape[0], numbers.Integral)
@@ -50,13 +51,23 @@ class CuPyDense(data.Data):
             raise ValueError(
                 f"shape must be a 2-tuple of positive ints, but is {shape!r}"
             )
-        if shape and (shape[0] != base.shape[0] or shape[1] != base.shape[1]):
+        if len(base.shape) == 2 and (
+            shape[0] != base.shape[0] or shape[1] != base.shape[1]
+        ):
             if shape[0] * shape[1] != base.size:
                 raise ValueError(
                     f"invalid shape {shape} for input data with size {base.shape}"
                 )
             else:
                 self._cp = base.reshape(shape)
+        elif len(base.shape) == 1:
+            if shape[0] * shape[1] != base.size:
+                raise ValueError(
+                    f"invalid shape {shape} for input data with size {base.shape}"
+                )
+            else:
+                self._cp = base.reshape(shape)
+
         else:
             self._cp = base
 

--- a/src/qutip_cupy/dense.py
+++ b/src/qutip_cupy/dense.py
@@ -38,9 +38,11 @@ class CuPyDense(data.Data):
         base = cp.array(data, dtype=self.dtype, order="K", copy=copy)
         if shape is None:
             shape = base.shape
+            if len(shape) == 0:
+                shape = (1, 1)
             # Promote to a ket by default if passed 1D data.
-        if len(shape) == 1:
-            shape = (shape[0], 1)
+            if len(shape) == 1:
+                shape = (shape[0], 1)
         if not (
             len(shape) == 2
             and isinstance(shape[0], numbers.Integral)
@@ -49,27 +51,21 @@ class CuPyDense(data.Data):
             and shape[1] > 0
         ):
             raise ValueError(
-                f"shape must be a 2-tuple of positive ints, but is {shape!r}"
+                "shape must be a 2-tuple of positive ints, but is " + repr(shape)
             )
-        if len(base.shape) == 2 and (
-            shape[0] != base.shape[0] or shape[1] != base.shape[1]
-        ):
-            if shape[0] * shape[1] != base.size:
-                raise ValueError(
-                    f"invalid shape {shape} for input data with size {base.shape}"
+        if shape[0] * shape[1] != base.size:
+            raise ValueError(
+                "".join(
+                    [
+                        "invalid shape ",
+                        str(shape),
+                        " for input data with size ",
+                        str(base.size),
+                    ]
                 )
-            else:
-                self._cp = base.reshape(shape)
-        elif len(base.shape) == 1:
-            if shape[0] * shape[1] != base.size:
-                raise ValueError(
-                    f"invalid shape {shape} for input data with size {base.shape}"
-                )
-            else:
-                self._cp = base.reshape(shape)
+            )
 
-        else:
-            self._cp = base
+        self._cp = base.reshape(shape)
 
         super().__init__((shape[0], shape[1]))
 

--- a/tests/test_dense.py
+++ b/tests/test_dense.py
@@ -30,6 +30,16 @@ class TestCuPyDenseDispatch:
 class TestCuPyDense:
     """ Tests of the methods and constructors of the CuPyDense class. """
 
+    @pytest.mark.parametrize(["shape"], [pytest.param((5,)), pytest.param((3))])
+    def test_init_promotion_to_ket(sef, shape):
+        cupy_dense = CuPyDense(np.random.uniform(size=shape))
+        assert len(cupy_dense.shape) == 2
+        if isinstance(shape, int):
+            size = shape
+        else:
+            size = shape[0]
+        assert cupy_dense.shape == (size, 1)
+
     def test_shape(self, shape):
         cupy_dense = CuPyDense(np.random.uniform(size=shape))
         assert cupy_dense.shape == shape


### PR DESCRIPTION
This fixes and tests CuPyDense init to properly promote 1d arrays to kets as done in QuTiP.

This is needed before  columns split cupydense function gets merged.

