### PR TITLE
split_columns_dense

### DIFF
--- a/src/qutip_cupy/__init__.py
+++ b/src/qutip_cupy/__init__.py
@@ -59,7 +59,7 @@ data.tidyup.add_specialisations([(CuPyDense, cdf.tidyup_dense)])
 data.trace.add_specialisations([(CuPyDense, cdf.trace_cupydense)])
 data.reshape.add_specialisations([(CuPyDense, CuPyDense, cdf.reshape_cupydense)])
 
-data.split_columns.add_specialisations([CuPyDense, cdf.split_columns_cupydense])
+data.split_columns.add_specialisations([(CuPyDense, cdf.split_columns_cupydense)])
 
 data.inner.add_specialisations([(CuPyDense, CuPyDense, cdf.inner_cupydense)])
 data.inner_op.add_specialisations(

--- a/src/qutip_cupy/__init__.py
+++ b/src/qutip_cupy/__init__.py
@@ -58,6 +58,7 @@ data.tidyup.add_specialisations([(CuPyDense, cdf.tidyup_dense)])
 data.trace.add_specialisations([(CuPyDense, cdf.trace_cupydense)])
 data.reshape.add_specialisations([(CuPyDense, CuPyDense, cdf.reshape_cupydense)])
 
+data.split_columns.add_specialisations([CuPyDense, cdf.split_columns_cupydense])
 # We must register the functions to the data layer but do not want
 # the data layer or qutip_cupy.dense to be accessible from qutip_cupy
 del data

--- a/src/qutip_cupy/dense_functions.py
+++ b/src/qutip_cupy/dense_functions.py
@@ -29,3 +29,7 @@ def trace_cupydense(cp_arr):
     # @TODO: whnen qutip allows it we should remove this call to item()
     # as it takes a time penalty commmunicating data from GPU to CPU.
     return cp.trace(cp_arr._cp).item()
+
+
+def split_columns_cupydense(cp_arr, copy=True):
+    return [CuPyDense(cp_arr._cp[:, k], copy=copy) for k in range(cp_arr.shape[1])]

--- a/src/qutip_cupy/dense_functions.py
+++ b/src/qutip_cupy/dense_functions.py
@@ -33,7 +33,7 @@ def trace_cupydense(cp_arr):
 
 def split_columns_cupydense(cp_arr, copy=True):
     return [CuPyDense(cp_arr._cp[:, k], copy=copy) for k in range(cp_arr.shape[1])]
- 
+
 
 def _check_shape_inner(left, right):
     if (left.shape[0] != 1 and left.shape[1] != 1) or right.shape[1] != 1:
@@ -155,4 +155,3 @@ def project_cupydense(state):
         return CuPyDense._raw_cupy_constructor(cp.outer(state.adjoint()._cp, state._cp))
     else:
         raise ValueError("state must be a ket or a bra.")
-

--- a/tests/test_mathematics.py
+++ b/tests/test_mathematics.py
@@ -1,4 +1,6 @@
 import cupy as cp
+from cupy._creation.from_data import asarray
+import numpy as np
 import pytest
 
 from qutip_cupy import dense
@@ -85,4 +87,16 @@ class TestTranspose(test_tools.TestTranspose):
 
     specialisations = [
         pytest.param(dense.transpose_cupydense, CuPyDense, CuPyDense),
+    ]
+
+
+class TestSplitColumns(test_tools.UnaryOpMixin):
+    def op_numpy(self, matrix, copy=True):
+        return [
+            np.array(matrix[:, k], copy=copy).reshape(matrix.shape[0], 1)
+            for k in range(matrix.shape[1])
+        ]
+
+    specialisations = [
+        pytest.param(cdf.split_columns_cupydense, CuPyDense, list),
     ]


### PR DESCRIPTION
For this to pass the tests #34 needs to be merged first.

This implements QuTiP's split_columns functiuon for CuPyDense.

Tests which are not on QuTiP's test mathematics have been added.
