### PR TITLE
Add `column_stack`, `column_unstack` and remove operators.

### DIFF
--- a/src/qutip_cupy/__init__.py
+++ b/src/qutip_cupy/__init__.py
@@ -65,8 +65,10 @@ data.zeros.add_specialisations([(CuPyDense, cd.zeros)])
 # dense_functions
 data.tidyup.add_specialisations([(CuPyDense, cdf.tidyup_dense)])
 data.trace.add_specialisations([(CuPyDense, cdf.trace_cupydense)])
-data.reshape.add_specialisations([(CuPyDense, CuPyDense, cdf.reshape_cupydense)])
 
+data.reshape.add_specialisations([(CuPyDense, CuPyDense, cdf.reshape_cupydense)])
+data.column_stack.add_specialisations([(CuPyDense, CuPyDense, cdf.column_stack_cupydense)])
+data.column_unstack.add_specialisations([(CuPyDense, CuPyDense, cdf.column_unstack_cupydense)])
 data.split_columns.add_specialisations([(CuPyDense, cdf.split_columns_cupydense)])
 
 data.inner.add_specialisations([(CuPyDense, CuPyDense, cdf.inner_cupydense)])

--- a/src/qutip_cupy/dense.py
+++ b/src/qutip_cupy/dense.py
@@ -295,7 +295,8 @@ def trace_cupydense(cpd_array):
 
 def imul_cupydense(cpd_array, value):
     """Multiply this CuPyDense `cpd_array` by a complex scalar `value`."""
-    return cpd_array._cp.__imul__(value)
+    cpd_array._cp.__imul__(value)
+    return cpd_array
 
 
 def mul_cupydense(cpd_array, value):

--- a/src/qutip_cupy/dense.py
+++ b/src/qutip_cupy/dense.py
@@ -320,7 +320,6 @@ def matmul_cupydense(left, right, scale=1, out=None):
     # but the GPU timings which are not very different.
     if out is None:
         return CuPyDense._raw_cupy_constructor(left._cp @ right._cp * scale)
-        (left @ right) * scale
     else:
         out._cp += (left._cp @ right._cp) * scale
         return out

--- a/src/qutip_cupy/dense.py
+++ b/src/qutip_cupy/dense.py
@@ -295,12 +295,12 @@ def trace_cupydense(cpd_array):
 
 def imul_cupydense(cpd_array, value):
     """Multiply this CuPyDense `cpd_array` by a complex scalar `value`."""
-    return self._cp.__imul__(value)
+    return cpd_array._cp.__imul__(value)
 
 
 def mul_cupydense(cpd_array, value):
     """Multiply this Dense `cpd_array` by a complex scalar `value`."""
-    return CuPyDense._raw_cupy_constructor(dense._cp * value)
+    return CuPyDense._raw_cupy_constructor(cpd_array._cp * value)
 
 
 def neg_cupydense(cpd_array):

--- a/src/qutip_cupy/dense_functions.py
+++ b/src/qutip_cupy/dense_functions.py
@@ -22,6 +22,12 @@ def column_stack_cupydense(cp_arr):
 
 
 def column_unstack_cupydense(cp_arr, rows):
+    if cp_arr.shape[1] != 1:
+        raise ValueError("input is not a single column")
+    if rows < 1:
+        raise ValueError("rows must be a positive integer")
+    if cp_arr.shape[0] % rows:
+        raise ValueError("number of rows does not divide into the shape")
     return CuPyDense._raw_cupy_constructor(
         cp.reshape(cp_arr._cp, (rows, -1), order="F")
     )

--- a/src/qutip_cupy/dense_functions.py
+++ b/src/qutip_cupy/dense_functions.py
@@ -10,9 +10,20 @@ def tidyup_dense(matrix, tol, inplace=True):
 
 
 def reshape_cupydense(cp_arr, n_rows_out, n_cols_out):
-
     return CuPyDense._raw_cupy_constructor(
         cp.reshape(cp_arr._cp, (n_rows_out, n_cols_out))
+    )
+
+
+def column_stack_cupydense(cp_arr):
+    return CuPyDense._raw_cupy_constructor(
+        cp.reshape(cp_arr._cp, (-1, 1), order="F")
+    )
+
+
+def column_unstack_cupydense(cp_arr, rows):
+    return CuPyDense._raw_cupy_constructor(
+        cp.reshape(cp_arr._cp, (rows, -1), order="F")
     )
 
 

--- a/tests/test_mathematics.py
+++ b/tests/test_mathematics.py
@@ -9,6 +9,7 @@ from qutip_cupy import CuPyDense
 from qutip_cupy.expectation import expect_cupydense
 
 import qutip.tests.core.data.test_mathematics as test_tools
+import qutip.tests.core.data.test_reshape as test_reshape_tools
 import qutip.tests.core.data.test_expect as test_expect_tools
 from qutip.core.data import Data
 
@@ -135,15 +136,31 @@ class TestHerm:
         assert not cdf.isherm_cupydense(base * 1j, tol=self.tol)
 
 
-class TestSplitColumns(test_tools.UnaryOpMixin):
-    def op_numpy(self, matrix, copy=True):
-        return [
-            np.array(matrix[:, k], copy=copy).reshape(matrix.shape[0], 1)
-            for k in range(matrix.shape[1])
-        ]
+class TestSplitColumns(test_reshape_tools.TestSplitColumns):
 
     specialisations = [
         pytest.param(cdf.split_columns_cupydense, CuPyDense, list),
+    ]
+
+
+class TestColumnStack(test_reshape_tools.TestColumnStack):
+
+    specialisations = [
+        pytest.param(cdf.column_stack_cupydense, CuPyDense, CuPyDense),
+    ]
+
+
+class TestColumnUnstack(test_reshape_tools.TestColumnUnstack):
+
+    specialisations = [
+        pytest.param(cdf.column_unstack_cupydense, CuPyDense, CuPyDense),
+    ]
+
+
+class TestReshape(test_reshape_tools.TestReshape):
+
+    specialisations = [
+        pytest.param(cdf.reshape_cupydense, CuPyDense, CuPyDense),
     ]
 
 


### PR DESCRIPTION
Add specializations for `column_stack`, `column_unstack` which are needed for `mesolve`.

Also remove the operators for `CupyDense`. Since qutip/qutip#1954, they are included in `base.Data` to support operations between different formats.